### PR TITLE
Remove support for PHP < 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
     "type": "library",
     "require": {
         "php": ">=7.3",
-        "guzzlehttp/guzzle": "^6.3 || ^7.0"
+        "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "9.*",
-        "vimeo/psalm": "^4.9"
+        "vimeo/psalm": "^4.18"
     },
     "autoload": {
         "psr-4": {

--- a/tests/SDKTest.php
+++ b/tests/SDKTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 final class SDKTest extends TestCase {
     public function testAuction(): void {
         // my localhost engine
-        $sdk = new SDK('babytuto', '6f62f7fd-8c6f-40f2-aa6e-10649638b2f9');
+        $sdk = new SDK('my_marketplace', '6f62f7fd-8c6f-40f2-aa6e-10649638b2f9');
         $slots = [
             'sponsoredListings' => 1,
         ];


### PR DESCRIPTION
I though we were fine by setting different versions of Guzzle to allow for more
versions of PHP to use this library. The problem lies with how Guzzle handles
exceptions differently in 6.x and 7.x and that affects directly on how we can
handle exceptions efficiently in this library.

Also, PHP 7.3 reached EOL this year, so it should make sense stop supporting that version.

People that still want to use this library with an older version of PHP can still use the php@5.6 dev-branch